### PR TITLE
Add support for signal handling

### DIFF
--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -11,6 +11,8 @@ SECTIONS
     .text : ALIGN(4K) {
         _stext = .;
         *(.text.boot)
+        . = ALIGN(4K);
+        *(.text.signal_trampoline)
         *(.text .text.*)
         . = ALIGN(4K);
         _etext = .;

--- a/modules/axhal/linker.lds.S
+++ b/modules/axhal/linker.lds.S
@@ -98,6 +98,8 @@ SECTIONS {
     linkm2_PAGE_FAULT : { *(linkm2_PAGE_FAULT) }
     linkme_SYSCALL : { *(linkme_SYSCALL) }
     linkm2_SYSCALL : { *(linkm2_SYSCALL) }
+    linkme_POST_TRAP : { *(linkme_POST_TRAP) }
+    linkm2_POST_TRAP : { *(linkm2_POST_TRAP) }
     axns_resource : { *(axns_resource) }
 }
 INSERT AFTER .tbss;

--- a/modules/axhal/src/arch/aarch64/mod.rs
+++ b/modules/axhal/src/arch/aarch64/mod.rs
@@ -150,3 +150,5 @@ pub fn cpu_init() {
     set_exception_vector_base(exception_vector_base as usize);
     unsafe { write_page_table_root0(0.into()) }; // disable low address access in EL1
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/aarch64/signal.S
+++ b/modules/axhal/src/arch/aarch64/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.balign 4
+.global start_signal_trampoline
+start_signal_trampoline:
+    mov x8, #139
+    svc #0

--- a/modules/axhal/src/arch/aarch64/trap.S
+++ b/modules/axhal/src/arch/aarch64/trap.S
@@ -63,18 +63,20 @@
     b       .Lexception_return
 .endm
 
-.macro HANDLE_SYNC
+.macro HANDLE_SYNC, source
 .p2align 7
     SAVE_REGS
     mov     x0, sp
+    mov     x1, \source
     bl      handle_sync_exception
     b       .Lexception_return
 .endm
 
-.macro HANDLE_IRQ
+.macro HANDLE_IRQ, source
 .p2align 7
     SAVE_REGS
     mov     x0, sp
+    mov     x1, \source
     bl      handle_irq_exception
     b       .Lexception_return
 .endm
@@ -90,14 +92,14 @@ exception_vector_base:
     INVALID_EXCP 3 0
 
     // current EL, with SP_ELx
-    HANDLE_SYNC
-    HANDLE_IRQ
+    HANDLE_SYNC 1
+    HANDLE_IRQ 1
     INVALID_EXCP 2 1
     INVALID_EXCP 3 1
 
     // lower EL, aarch64
-    HANDLE_SYNC
-    HANDLE_IRQ
+    HANDLE_SYNC 2
+    HANDLE_IRQ 2
     INVALID_EXCP 2 2
     INVALID_EXCP 3 2
 

--- a/modules/axhal/src/arch/aarch64/trap.rs
+++ b/modules/axhal/src/arch/aarch64/trap.rs
@@ -27,6 +27,11 @@ enum TrapSource {
     LowerAArch64 = 2,
     LowerAArch32 = 3,
 }
+impl TrapSource {
+    fn is_from_user(&self) -> bool {
+        matches!(self, TrapSource::LowerAArch64 | TrapSource::LowerAArch32)
+    }
+}
 
 #[unsafe(no_mangle)]
 fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
@@ -37,8 +42,9 @@ fn invalid_exception(tf: &TrapFrame, kind: TrapKind, source: TrapSource) {
 }
 
 #[unsafe(no_mangle)]
-fn handle_irq_exception(_tf: &TrapFrame) {
+fn handle_irq_exception(tf: &mut TrapFrame, source: TrapSource) {
     handle_trap!(IRQ, 0);
+    crate::trap::post_trap_callback(tf, source.is_from_user());
 }
 
 fn handle_instruction_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
@@ -94,7 +100,7 @@ fn handle_data_abort(tf: &TrapFrame, iss: u64, is_user: bool) {
 }
 
 #[unsafe(no_mangle)]
-fn handle_sync_exception(tf: &mut TrapFrame) {
+fn handle_sync_exception(tf: &mut TrapFrame, source: TrapSource) {
     let esr = ESR_EL1.extract();
     let iss = esr.read(ESR_EL1::ISS);
     match esr.read_as_enum(ESR_EL1::EC) {
@@ -120,4 +126,5 @@ fn handle_sync_exception(tf: &mut TrapFrame) {
             );
         }
     }
+    crate::trap::post_trap_callback(tf, source.is_from_user());
 }

--- a/modules/axhal/src/arch/loongarch64/mod.rs
+++ b/modules/axhal/src/arch/loongarch64/mod.rs
@@ -210,3 +210,5 @@ pub fn cpu_init() {
     }
     set_exception_entry_base(exception_entry_base as usize);
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/loongarch64/signal.S
+++ b/modules/axhal/src/arch/loongarch64/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.balign 4
+.global start_signal_trampoline
+start_signal_trampoline:
+    li.w    $a7, 139
+    syscall 0

--- a/modules/axhal/src/arch/loongarch64/trap.rs
+++ b/modules/axhal/src/arch/loongarch64/trap.rs
@@ -69,4 +69,6 @@ fn loongarch64_trap_handler(tf: &mut TrapFrame, from_user: bool) {
             );
         }
     }
+
+    crate::trap::post_trap_callback(tf, from_user);
 }

--- a/modules/axhal/src/arch/riscv/context.rs
+++ b/modules/axhal/src/arch/riscv/context.rs
@@ -174,7 +174,7 @@ impl TrapFrame {
 
 /// Context to enter user space.
 #[cfg(feature = "uspace")]
-pub struct UspaceContext(TrapFrame);
+pub struct UspaceContext(pub TrapFrame);
 
 #[cfg(feature = "uspace")]
 impl UspaceContext {

--- a/modules/axhal/src/arch/riscv/mod.rs
+++ b/modules/axhal/src/arch/riscv/mod.rs
@@ -119,3 +119,5 @@ pub fn cpu_init() {
     }
     set_trap_vector_base(trap_vector_base as usize);
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/riscv/signal.S
+++ b/modules/axhal/src/arch/riscv/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.balign 4
+.global start_signal_trampoline
+start_signal_trampoline:
+    li a7, 139
+    ecall

--- a/modules/axhal/src/arch/riscv/trap.rs
+++ b/modules/axhal/src/arch/riscv/trap.rs
@@ -60,6 +60,7 @@ fn riscv_trap_handler(tf: &mut TrapFrame, from_user: bool) {
                 panic!("Unhandled trap {:?} @ {:#x}:\n{:#x?}", cause, tf.sepc, tf);
             }
         }
+        crate::trap::post_trap_callback(tf, from_user);
     } else {
         panic!(
             "Unknown trap {:?} @ {:#x}:\n{:#x?}",

--- a/modules/axhal/src/arch/x86_64/mod.rs
+++ b/modules/axhal/src/arch/x86_64/mod.rs
@@ -133,3 +133,5 @@ pub fn cpu_init() {
     #[cfg(feature = "uspace")]
     init_syscall();
 }
+
+core::arch::global_asm!(include_str!("signal.S"));

--- a/modules/axhal/src/arch/x86_64/signal.S
+++ b/modules/axhal/src/arch/x86_64/signal.S
@@ -1,0 +1,6 @@
+.section .text.signal_trampoline
+.code64
+.global start_signal_trampoline
+start_signal_trampoline:
+    mov rax, 0xf
+    syscall

--- a/modules/axhal/src/arch/x86_64/syscall.S
+++ b/modules/axhal/src/arch/x86_64/syscall.S
@@ -30,6 +30,10 @@ syscall_entry:
     mov     rdi, rsp
     call    x86_syscall_handler
 
+    mov     rdi, rsp
+    mov     rsi, 1 // is_user
+    call    post_trap_callback
+
     pop     rax
     pop     rcx
     pop     rdx

--- a/modules/axhal/src/arch/x86_64/trap.rs
+++ b/modules/axhal/src/arch/x86_64/trap.rs
@@ -56,6 +56,7 @@ fn x86_trap_handler(tf: &mut TrapFrame) {
             );
         }
     }
+    crate::trap::post_trap_callback(tf, tf.is_user());
 }
 
 fn vec_to_str(vec: u64) -> &'static str {


### PR DESCRIPTION
## Description  

This PR adds support for signal handling, which includes:

- Refactoring `UspaceContext` & `TrapFrame` so that more registers (including argx, retval, ra) are exposed
- Reserving a page as signal trampoline during linking
- Adding generic trap handling to handle any trap, allowing us to capture the returning from kernel to uspace
- Fixing `AddrSpace`: data of linear mapping should not be copied in `clone_or_err`

## How to Test  

Test results at [starry-next#signal](https://github.com/Mivik/starry-next/tree/signal)

| riscv | x86_64 | loongarch64 |
|-|-|-|
|![image](https://github.com/user-attachments/assets/245728ea-a5de-4f1a-9190-17f4f564fd2b)|![image](https://github.com/user-attachments/assets/beb76f52-18a8-4ec2-a39c-6526f20425af)|![屏幕截图_20250327_100745](https://github.com/user-attachments/assets/6b363369-f761-4cf5-8628-088723cf9beb)|
